### PR TITLE
return nil for no background

### DIFF
--- a/lib/geo_pattern/pattern.rb
+++ b/lib/geo_pattern/pattern.rb
@@ -66,13 +66,8 @@ module GeoPattern
         geo_squares
       when 10
         geo_rings
-      when 11
+      when 11..16
         geo_diamonds
-      when 12
-      when 13
-      when 14
-      when 15
-      when 16
       end
     end
       


### PR DESCRIPTION
I want to be able to check on the client side when there wasn't a background generated. This way i'm not left with just a background color. so I've moved some stuff around. It now returns `nil` if there wasn't a background pattern generated. rather than just a square with a solid color.

@andrew @jasonlong
