### PR TITLE
Adding uri to background-image example

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Get the Base64 encoded string:
 
 You can then use this string to set the background:
 
-    <div style="background-image: <%=pattern.background_image%>"></div>
+    <div style="background-image: <%=pattern.uri_image%>"></div>
 
 ## Available patterns
 

--- a/lib/geo_pattern/pattern.rb
+++ b/lib/geo_pattern/pattern.rb
@@ -57,7 +57,7 @@ module GeoPattern
       Base64.strict_encode64(svg.to_s)
     end
 
-    def background_image
+    def uri_image
       "url(data:image/svg+xml;base64,#{base64_string});"
     end
 


### PR DESCRIPTION
Hi there,

First off cool gem, I was playing around with it last night and I noticed your example for background image was missing the data uri for the background image.  I couldn't get my image to generate just using 

```
<div style="background-image: <%=pattern.base64_string%>"></div>
```

I looked at the @github guides and noticed that you needed to add the image uri to the base64 string. So I modified the README.

Thanks!

Do you think this would be worth adding to the gem? For example you could do

```
<div style="background-image: <%=pattern.background_image%>"></div>
```

And it could just give you the uri and base64 string?
