### PR TITLE
fix reading beyond hash length

### DIFF
--- a/lib/geo_pattern/pattern.rb
+++ b/lib/geo_pattern/pattern.rb
@@ -431,7 +431,7 @@ module GeoPattern
                     }
                   })
 
-          val     = hex_val(40-i, 1)
+          val     = hex_val(39-i, 1)
           opacity = opacity(val)
           fill    = fill_color(val)
 
@@ -654,7 +654,7 @@ module GeoPattern
                     y*square_size + y*block_size*2 + block_size/2,
                     square_size, square_size, styles)
 
-          val     = hex_val(40-i, 1)
+          val     = hex_val(39-i, 1)
           opacity = opacity(val)
           fill    = fill_color(val)
 


### PR DESCRIPTION
In the concentric circles and nested squares patterns, when `i = 0` i.e. the top left corner of the pattern, `val` for the inner shape is read from `hash[40]`, but the hash itself is only 40 characters long.
