### PR TITLE
Fixed coloring issue.

### DIFF
--- a/lib/geo_pattern/pattern.rb
+++ b/lib/geo_pattern/pattern.rb
@@ -658,6 +658,15 @@ module GeoPattern
           opacity = opacity(val)
           fill    = fill_color(val)
 
+          styles = {
+            "fill"   => "none",
+            "stroke" => fill,
+            "style"  => {
+              "opacity" => opacity,
+              "stroke-width" => "#{block_size}px"
+            }
+          }
+
           svg.rect(x*square_size + x*block_size*2 + block_size/2 + block_size*2,
                     y*square_size + y*block_size*2 + block_size/2 + block_size*2,
                     block_size * 3, block_size * 3, styles)


### PR DESCRIPTION
I'm not sure if this bug was intentional or not with the nested_squares. New opacity and fill values were being generated for the inner rectangle, but they were never actually used because the styles weren't updated with the new values. I've fixed that here. I've also included an example of the new image. Original is on the left, new is on the right.

![screenshot 2014-02-25 15 59 45](https://f.cloud.github.com/assets/551002/2262987/03cb9882-9e60-11e3-9de5-b33bef59a3c2.png)
