### PR TITLE
Bugfix: NoMethodError: undefined method `<' for nil:NilClass

### DIFF
--- a/lib/geo_pattern/pattern_generator.rb
+++ b/lib/geo_pattern/pattern_generator.rb
@@ -81,21 +81,21 @@ module GeoPattern
     end
 
     def generate_pattern
-      if opts[:generator].is_a? String
-        generator = PATTERNS[opts[:generator]]
-        puts SVG.as_comment("String pattern references are deprecated as of 1.3.0")
-      elsif opts[:generator] < BasePattern
-        if PATTERNS.values.include? opts[:generator]
-          generator = opts[:generator]
-        else
-          abort("Error: the requested generator is invalid")
-          generator = nil
+      unless opts[:generator].nil?
+        if opts[:generator].is_a? String
+          generator = PATTERNS[opts[:generator]]
+          puts SVG.as_comment("String pattern references are deprecated as of 1.3.0")
+        elsif opts[:generator] < BasePattern
+          if PATTERNS.values.include? opts[:generator]
+            generator = opts[:generator]
+          else
+            abort("Error: the requested generator is invalid")
+            generator = nil
+          end
         end
       end
 
-      if generator.nil?
-        generator = PATTERNS.values[[PatternHelpers.hex_val(hash, 20, 1), PATTERNS.length - 1].min]
-      end
+      generator ||= PATTERNS.values[[PatternHelpers.hex_val(hash, 20, 1), PATTERNS.length - 1].min]
 
       # Instantiate the generator with the needed references
       # and render the pattern to the svg object


### PR DESCRIPTION
When I run

``` ruby
GeoPattern.generate('How do I get started', :color => '#7A3332')
```

I get the following error

```
NoMethodError: undefined method `<' for nil:NilClass
from /opt/boxen/rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/geo_pattern-1.3.0/lib/geo_pattern/pattern_generator.rb:87:in `generate_pattern'
```

This PR fixes the issue for me, let me know if you want any changes.

Thanks!
