### PR TITLE
Add background color accessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,19 @@ You can then use this string to set the background:
 <div style="background-image: <%= pattern.uri_image %>"></div>
 ```
 
+Get the base color:
+
+```ruby
+puts pattern.color.html
+# => "#3f904d"
+```
+
+You can use it as a fallback for browsers without SVG support, or to style other elements accordingly:
+
+```html
+<div style="background-color: <%= pattern.color.html %>"></div>
+```
+
 ## Available patterns
 
 *Note: As of version `1.3.0`, string references (e.g. `overlapping_circles`) are deprecated in favor of class references (e.g. `GeoPattern::OverlappingCirclesPattern`).*

--- a/lib/geo_pattern/pattern_generator.rb
+++ b/lib/geo_pattern/pattern_generator.rb
@@ -13,7 +13,7 @@ module GeoPattern
 
     private
 
-    attr_reader :opts, :hash, :svg
+    attr_reader :opts, :hash, :svg, :color
 
     public
 
@@ -40,13 +40,13 @@ module GeoPattern
     end
 
     def generate_background
-      color = if opts[:color]
+      @color = if opts[:color]
                 PatternHelpers.html_to_rgb(opts[:color])
               else
                 PatternHelpers.html_to_rgb_for_string(hash, opts[:base_color])
               end
 
-      svg.rect(0, 0, "100%", "100%", "fill" => color)
+      svg.rect(0, 0, "100%", "100%", "fill" => @color)
     end
 
     def generate_pattern

--- a/spec/geo_pattern_spec.rb
+++ b/spec/geo_pattern_spec.rb
@@ -17,6 +17,11 @@ RSpec.describe GeoPattern do
       expect(pattern1.svg_string).to eq pattern2.svg_string
     end
 
+    it 'exposes the background color' do
+      pattern = GeoPattern.generate(string)
+      expect(pattern.color.html).to eq('#3f904d')
+    end
+
     it 'sets background color with adjusting hue and saturation based on string' do
       string = 'Mastering Markdown'
       hash = Digest::SHA1.hexdigest string


### PR DESCRIPTION
I saw this on the js version and it seemed really usefull to me for fallback or styling other element.
I was sad to see it wasn't in the ruby version :cry: so here it is!