### PR TITLE
Removed duplicate entry (chevrons) in 'Available Patterns'

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,10 +158,6 @@ are deprecated in favor of symbol references (e.g. `:overlapping_circles`).*
 
 ![](http://jasonlong.github.io/geo_pattern/examples/tessellation.png)
 
-### :chevrons
-
-![](http://jasonlong.github.io/geo_pattern/examples/chevrons.png)
-
 
 ## Inspection of pattern
 


### PR DESCRIPTION
`:chevrons` was listed twice, at the top and bottom of the list. I removed the second, redundant one from the file.