### PR TITLE
Add link to a rust port

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,3 +267,6 @@ https://github.com/mattfxyz/GeoPattern-Cocoa
 
 Middleman extension by @maxmeyer:
 https://github.com/fedux-org/middleman-geo_pattern
+
+Rust port with a WASM demo by @suyash:
+https://github.com/suyash/geopattern


### PR DESCRIPTION
Implemented a rust crate with a WebAssembly demo using rust's `wasm32-unknown-unknown` target. 

The example is up on https://suy.io/geopattern/. It is basically a reimplementation of a SHA1 example (https://www.hellorust.com/demos/sha1/index.html), but builds geopatterns. Thats where I got the idea.

As a rust newbie, it was a fun weekend project to hack on, thanks for the original one.