### PR TITLE
Add TypeScript port

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,9 @@ RSPEC_PROFILE=1 bundle exec rspec
 JavaScript port by Brandon Mills:
 https://github.com/btmills/geopattern
 
+TypeScript port by MooYeol Lee:
+https://github.com/mooyoul/geo-pattern
+
 Python port by Bryan Veloso:
 https://github.com/bryanveloso/geopatterns
 


### PR DESCRIPTION
I needed to TypeScript support and Node.js support (including Browser-side support of course), so I've created TypeScript port of geo-pattern.

Package was tested with [geo_pattern gem outputs](https://github.com/mooyoul/geo-pattern/blob/master/fixtures/generate.ts), and [generated output 100% matches to the original gem.](https://github.com/mooyoul/geo-pattern/blob/master/integration-test/node/node.e2e.ts#L20)

Also, This TypeScript port supports not only Node.js usage but also Browser usage.
Live Example is available on https://mooyoul.github.io/geo-pattern/
[Browser compatibility test results](https://github.com/mooyoul/geo-pattern/#e2e-test-status) are available too.

It was a super fun project to dive in, thanks for the your efforts to this project ;)

