### PR TITLE
Add ruby 3.1 / 3.2 to test matrix + fix failing GH action tests for 2.6 / 2.7

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -23,6 +23,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+          rubygems: latest
           bundler-cache: true
 
       - name: Run tests

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-        ruby: [2.6, 2.7, '3.0', head]
+        ruby: [2.6, 2.7, '3.0', '3.1', '3.2', head]
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-        ruby: [2.6, 2.7, '3.0', '3.1', '3.2', head]
+        ruby: [2.6, 2.7, '3.0', 3.1, 3.2, head]
 
     runs-on: ubuntu-latest
 

--- a/geo_pattern.gemspec
+++ b/geo_pattern.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |spec|
 
   spec.files = `git ls-files -z`.split("\x0")
   spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.6"

--- a/lib/geo_pattern/helpers.rb
+++ b/lib/geo_pattern/helpers.rb
@@ -3,7 +3,7 @@
 module GeoPattern
   module Helpers
     def require_files_matching_pattern(pattern)
-      Dir.glob(pattern).each { |f| require_relative f }
+      Dir.glob(pattern).sort.each { |f| require_relative f }
     end
 
     # Makes an underscored, lowercase form from the expression in the string.

--- a/lib/geo_pattern/structure_generators/chevrons_generator.rb
+++ b/lib/geo_pattern/structure_generators/chevrons_generator.rb
@@ -18,8 +18,8 @@ module GeoPattern
 
       def generate_structure
         i = 0
-        (0..5).each do |y|
-          (0..5).each do |x|
+        6.times do |y|
+          6.times do |x|
             val = hex_val(i, 1)
             opacity = opacity(val)
             fill = fill_color(val)

--- a/lib/geo_pattern/structure_generators/concentric_circles_generator.rb
+++ b/lib/geo_pattern/structure_generators/concentric_circles_generator.rb
@@ -17,8 +17,8 @@ module GeoPattern
 
       def generate_structure
         i = 0
-        (0..5).each do |y|
-          (0..5).each do |x|
+        6.times do |y|
+          6.times do |x|
             val = hex_val(i, 1)
             opacity = opacity(val)
             fill = fill_color(val)

--- a/lib/geo_pattern/structure_generators/diamonds_generator.rb
+++ b/lib/geo_pattern/structure_generators/diamonds_generator.rb
@@ -18,8 +18,8 @@ module GeoPattern
 
       def generate_structure
         i = 0
-        (0..5).each do |y|
-          (0..5).each do |x|
+        6.times do |y|
+          6.times do |x|
             val = hex_val(i, 1)
             opacity = opacity(val)
             fill = fill_color(val)
@@ -31,7 +31,7 @@ module GeoPattern
               "stroke-opacity" => stroke_opacity
             }
 
-            dx = y % 2 == 0 ? 0 : diamond_width / 2
+            dx = (y % 2 == 0) ? 0 : diamond_width / 2
 
             svg.polyline(diamond, styles.merge(
               "transform" => "translate(#{x * diamond_width - diamond_width / 2 + dx}, #{diamond_height / 2 * y - diamond_height / 2})"

--- a/lib/geo_pattern/structure_generators/hexagons_generator.rb
+++ b/lib/geo_pattern/structure_generators/hexagons_generator.rb
@@ -20,10 +20,10 @@ module GeoPattern
 
       def generate_structure
         i = 0
-        (0..5).each do |y|
-          (0..5).each do |x|
+        6.times do |y|
+          6.times do |x|
             val = hex_val(i, 1)
-            dy = x % 2 == 0 ? y * hex_height : y * hex_height + hex_height / 2
+            dy = (x % 2 == 0) ? y * hex_height : y * hex_height + hex_height / 2
             opacity = opacity(val)
             fill = fill_color(val)
 
@@ -43,7 +43,7 @@ module GeoPattern
 
             # Add an extra row at the end that matches the first row, for tiling.
             if y == 0
-              dy = x % 2 == 0 ? 6 * hex_height : 6 * hex_height + hex_height / 2
+              dy = (x % 2 == 0) ? 6 * hex_height : 6 * hex_height + hex_height / 2
               svg.polyline(hex, styles.merge("transform" => "translate(#{x * side_length * 1.5 - hex_width / 2}, #{dy - hex_height / 2})"))
             end
 

--- a/lib/geo_pattern/structure_generators/mosaic_squares_generator.rb
+++ b/lib/geo_pattern/structure_generators/mosaic_squares_generator.rb
@@ -15,8 +15,8 @@ module GeoPattern
 
       def generate_structure
         i = 0
-        (0..3).each do |y|
-          (0..3).each do |x|
+        4.times do |y|
+          4.times do |x|
             if x.even?
               if y.even?
                 draw_outer_mosaic_tile(x * triangle_size * 2, y * triangle_size * 2, triangle_size, hex_val(i, 1))

--- a/lib/geo_pattern/structure_generators/nested_squares_generator.rb
+++ b/lib/geo_pattern/structure_generators/nested_squares_generator.rb
@@ -16,8 +16,8 @@ module GeoPattern
 
       def generate_structure
         i = 0
-        (0..5).each do |y|
-          (0..5).each do |x|
+        6.times do |y|
+          6.times do |x|
             val = hex_val(i, 1)
             opacity = opacity(val)
             fill = fill_color(val)

--- a/lib/geo_pattern/structure_generators/octagons_generator.rb
+++ b/lib/geo_pattern/structure_generators/octagons_generator.rb
@@ -16,8 +16,8 @@ module GeoPattern
 
       def generate_structure
         i = 0
-        (0..5).each do |y|
-          (0..5).each do |x|
+        6.times do |y|
+          6.times do |x|
             val = hex_val(i, 1)
             opacity = opacity(val)
             fill = fill_color(val)

--- a/lib/geo_pattern/structure_generators/overlapping_circles_generator.rb
+++ b/lib/geo_pattern/structure_generators/overlapping_circles_generator.rb
@@ -17,8 +17,8 @@ module GeoPattern
 
       def generate_structure
         i = 0
-        (0..5).each do |y|
-          (0..5).each do |x|
+        6.times do |y|
+          6.times do |x|
             val = hex_val(i, 1)
             opacity = opacity(val)
             fill = fill_color(val)

--- a/lib/geo_pattern/structure_generators/overlapping_rings_generator.rb
+++ b/lib/geo_pattern/structure_generators/overlapping_rings_generator.rb
@@ -17,8 +17,8 @@ module GeoPattern
 
       def generate_structure
         i = 0
-        (0..5).each do |y|
-          (0..5).each do |x|
+        6.times do |y|
+          6.times do |x|
             val = hex_val(i, 1)
             opacity = opacity(val)
             fill = fill_color(val)

--- a/lib/geo_pattern/structure_generators/plus_signs_generator.rb
+++ b/lib/geo_pattern/structure_generators/plus_signs_generator.rb
@@ -17,12 +17,12 @@ module GeoPattern
 
       def generate_structure
         i = 0
-        (0..5).each do |y|
-          (0..5).each do |x|
+        6.times do |y|
+          6.times do |x|
             val = hex_val(i, 1)
             opacity = opacity(val)
             fill = fill_color(val)
-            dx = y % 2 == 0 ? 0 : 1
+            dx = (y % 2 == 0) ? 0 : 1
 
             styles = {
               "fill" => fill,

--- a/lib/geo_pattern/structure_generators/sine_waves_generator.rb
+++ b/lib/geo_pattern/structure_generators/sine_waves_generator.rb
@@ -17,7 +17,7 @@ module GeoPattern
       end
 
       def generate_structure
-        (0..35).each do |i|
+        36.times do |i|
           val = hex_val(i, 1)
           opacity = opacity(val)
           fill = fill_color(val)

--- a/lib/geo_pattern/structure_generators/squares_generator.rb
+++ b/lib/geo_pattern/structure_generators/squares_generator.rb
@@ -15,8 +15,8 @@ module GeoPattern
 
       def generate_structure
         i = 0
-        (0..5).each do |y|
-          (0..5).each do |x|
+        6.times do |y|
+          6.times do |x|
             val = hex_val(i, 1)
             opacity = opacity(val)
             fill = fill_color(val)

--- a/lib/geo_pattern/structure_generators/tessellation_generator.rb
+++ b/lib/geo_pattern/structure_generators/tessellation_generator.rb
@@ -22,7 +22,7 @@ module GeoPattern
       end
 
       def generate_structure
-        (0..19).each do |i|
+        20.times do |i|
           val = hex_val(i, 1)
           opacity = opacity(val)
           fill = fill_color(val)

--- a/lib/geo_pattern/structure_generators/triangles_generator.rb
+++ b/lib/geo_pattern/structure_generators/triangles_generator.rb
@@ -19,8 +19,8 @@ module GeoPattern
 
       def generate_structure
         i = 0
-        (0..5).each do |y|
-          (0..5).each do |x|
+        6.times do |y|
+          6.times do |x|
             val = hex_val(i, 1)
             opacity = opacity(val)
             fill = fill_color(val)
@@ -33,9 +33,9 @@ module GeoPattern
             }
 
             rotation = if y % 2 == 0
-              x % 2 == 0 ? 180 : 0
+              (x % 2 == 0) ? 180 : 0
             else
-              x % 2 != 0 ? 180 : 0
+              (x % 2 != 0) ? 180 : 0
             end
 
             svg.polyline(triangle, styles.merge(

--- a/lib/geo_pattern/structure_generators/xes_generator.rb
+++ b/lib/geo_pattern/structure_generators/xes_generator.rb
@@ -17,11 +17,11 @@ module GeoPattern
 
       def generate_structure
         i = 0
-        (0..5).each do |y|
-          (0..5).each do |x|
+        6.times do |y|
+          6.times do |x|
             val = hex_val(i, 1)
             opacity = opacity(val)
-            dy = x % 2 == 0 ? y * x_size - x_size * 0.5 : y * x_size - x_size * 0.5 + x_size / 4
+            dy = (x % 2 == 0) ? y * x_size - x_size * 0.5 : y * x_size - x_size * 0.5 + x_size / 4
             fill = fill_color(val)
 
             styles = {
@@ -44,7 +44,7 @@ module GeoPattern
 
             # Add an extra row on the bottom that matches the first row, for tiling.
             if y == 0
-              dy = x % 2 == 0 ? 6 * x_size - x_size / 2 : 6 * x_size - x_size / 2 + x_size / 4
+              dy = (x % 2 == 0) ? 6 * x_size - x_size / 2 : 6 * x_size - x_size / 2 + x_size / 4
               svg.group(x_shape, styles.merge(
                 "transform" => "translate(#{x * x_size / 2 - x_size / 2},#{dy - 6 * x_size / 2}) rotate(45, #{x_size / 2}, #{x_size / 2})"
               ))

--- a/spec/pattern_spec.rb
+++ b/spec/pattern_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Pattern do
   let(:background_body) { %(<rect x="0" y="0" width="100%" height="100%" fill="rgb(121, 131, 76)"  />) }
   let(:structure) { instance_double("GeoPattern::Structure") }
   let(:structure_image) { instance_double("GeoPattern::SvgImage") }
-  let(:structure_body) { %(<path d=\"M0 53 C 28.0 0, 52.0 0, 80 53 S 132.0 106, 160 53 S 212.0 0, 240.0, 53\" fill=\"none\" stroke=\"#222\" style=\"opacity:0.046;stroke-width:6px;\" transform=\"translate(-40, -79.5)\"  />) }
+  let(:structure_body) { %(<path d="M0 53 C 28.0 0, 52.0 0, 80 53 S 132.0 106, 160 53 S 212.0 0, 240.0, 53" fill="none" stroke="#222" style="opacity:0.046;stroke-width:6px;" transform="translate(-40, -79.5)"  />) }
 
   it { expect(pattern).not_to be_nil }
 


### PR DESCRIPTION
Hey all! Thanks so much for maintaining this wonderful gem for so long. Going through this because we're upgrading to ruby 3 soon & were checking out some of our own projects.

The changes are best reviewed by commit. tl;dr:

- standardrb linter was failing in GH actions, so this ran the [auto-formatter](https://github.com/jasonlong/geo_pattern/commit/ffe92e48df0d0c2c27b0fabd3e5e2e81ed74070b) + included [a manual fix](https://github.com/jasonlong/geo_pattern/commit/ab53719ab79c4695cfd4ca1471e11a2a42b1ef5c)
- Ruby 3.1 & 3.2 are now in the GH action test matrix (and pass)

---

These changes are mostly changes to CI and formatting. No expected change in the interfaces, ~~so I recommend releasing this as a patch (1.4.1).~~ EDIT: Looks like there are [a couple changes since the last tagged release](https://github.com/jasonlong/geo_pattern/compare/v1.4.0...47fed7fb0a1cfdf5c47d593ebd17f72b9d5ad87a), so ignore what I said about 1.4.1.